### PR TITLE
Implement support for SharedImages

### DIFF
--- a/Source/FossPDF.Examples/ImageExamples.cs
+++ b/Source/FossPDF.Examples/ImageExamples.cs
@@ -5,6 +5,7 @@ using FossPDF.Drawing.Exceptions;
 using FossPDF.Examples.Engine;
 using FossPDF.Fluent;
 using FossPDF.Helpers;
+using FossPDF.Infrastructure;
 
 namespace FossPDF.Examples
 {
@@ -47,6 +48,25 @@ namespace FossPDF.Examples
                 {
                     page.Padding(25)
                         .Image(Placeholders.Image);
+                });
+        }
+        
+        [Test]
+        public void SharedImage()
+        {
+            RenderingTest
+                .Create()
+                .PageSize(450, 350)
+                .ProducePdf()
+                .ShowResults()
+                .Render(page =>
+                {
+                    page.Column(column =>
+                    {
+                        var image = Image.FromBinaryData(Placeholders.Image(200, 100));
+                        column.Item().Image(image);
+                        column.Item().Image(image);
+                    });
                 });
         }
         

--- a/Source/FossPDF.UnitTests/ImageTests.cs
+++ b/Source/FossPDF.UnitTests/ImageTests.cs
@@ -15,7 +15,7 @@ namespace FossPDF.UnitTests
         public void Measure_TakesAvailableSpaceRegardlessOfSize()
         {
             TestPlan
-                .For(x => new Image
+                .For(x => new Elements.Image
                 {
                     InternalImage = GenerateImage(400, 300)
                 })
@@ -27,7 +27,7 @@ namespace FossPDF.UnitTests
         public void Draw_TakesAvailableSpaceRegardlessOfSize()
         {
             TestPlan
-                .For(x => new Image
+                .For(x => new Elements.Image
                 {
                     InternalImage = GenerateImage(400, 300)
                 })

--- a/Source/FossPDF/Fluent/ImageExtensions.cs
+++ b/Source/FossPDF/Fluent/ImageExtensions.cs
@@ -26,13 +26,18 @@ namespace FossPDF.Fluent
             var image = SKImage.FromEncodedData(fileStream);
             parent.Image(image, scaling);
         }
+
+        public static void Image(this IContainer parent, Infrastructure.Image image, ImageScaling scaling = ImageScaling.FitWidth)
+        {
+            parent.Image(image.SkImage, scaling);
+        }
         
         private static void Image(this IContainer parent, SKImage image, ImageScaling scaling = ImageScaling.FitWidth)
         {
             if (image == null)
                 throw new DocumentComposeException("Cannot load or decode provided image.");
             
-            var imageElement = new Image
+            var imageElement = new Elements.Image
             {
                 InternalImage = image
             };

--- a/Source/FossPDF/Infrastructure/Image.cs
+++ b/Source/FossPDF/Infrastructure/Image.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.IO;
+using SkiaSharp;
+
+namespace FossPDF.Infrastructure;
+
+public class Image : IDisposable
+{
+    internal SKImage SkImage { get; }
+
+    private Image(SKImage image)
+    {
+        SkImage = image;
+    }
+
+    public void Dispose() { }
+    
+    public static Image FromBinaryData(byte[] imageBytes)
+    {
+        var skImage = SKImage.FromEncodedData(imageBytes);
+        var createdImage = new Image(skImage);
+        return createdImage;
+    }
+    
+    public static Image FromFile(string filePath)
+    {
+        var skImage = SKImage.FromEncodedData(filePath);
+        var createdImage = new Image(skImage);
+        return createdImage;
+    }
+    
+    public static Image FromStream(Stream stream)
+    {
+        var skImage = SKImage.FromEncodedData(stream);
+        var createdImage = new Image(skImage);
+        return createdImage;
+    }
+}


### PR DESCRIPTION
This fixes lol768/FossPDF.Net#1. The image contains only one SKImage that is reused.