### PR TITLE
 Add the ability to get the total number of pages

### DIFF
--- a/Source/FossPDF/Drawing/DocumentGenerator.cs
+++ b/Source/FossPDF/Drawing/DocumentGenerator.cs
@@ -20,14 +20,14 @@ namespace FossPDF.Drawing
         {
             NativeDependencyCompatibilityChecker.Test();
         }
-
-        internal static void GeneratePdf(Stream stream, IDocument document)
+        
+        internal static int GeneratePdf(Stream stream, IDocument document)
         {
             CheckIfStreamIsCompatible(stream);
 
             var metadata = document.GetMetadata();
             var canvas = new PdfCanvas(stream, metadata);
-            RenderDocument(canvas, document);
+            return RenderDocument(canvas, document);
         }
 
         internal static void GenerateXps(Stream stream, IDocument document)
@@ -72,7 +72,7 @@ namespace FossPDF.Drawing
             return canvas.Pictures;
         }
 
-        internal static void RenderDocument<TCanvas>(TCanvas canvas, IDocument document)
+        internal static int RenderDocument<TCanvas>(TCanvas canvas, IDocument document)
             where TCanvas : ICanvas, IRenderingCanvas
         {
             var container = new DocumentContainer();
@@ -114,6 +114,8 @@ namespace FossPDF.Drawing
 
             RenderPass(pageContext, canvas, content, debuggingState);
             pageContext.FontManager.DisposeAll();
+
+            return pageContext.GetPageNumbers();
         }
 
         private static void ProcessElementPrepareForSubsetting(Element? el,

--- a/Source/FossPDF/Fluent/GenerateExtensions.cs
+++ b/Source/FossPDF/Fluent/GenerateExtensions.cs
@@ -12,20 +12,30 @@ namespace FossPDF.Fluent
         
         public static byte[] GeneratePdf(this IDocument document)
         {
+            return document.GeneratePdf(out var _);
+        }
+
+        public static byte[] GeneratePdf(this IDocument document, out int totalPages)
+        {
             using var stream = new MemoryStream();
-            document.GeneratePdf(stream);
+            totalPages = DocumentGenerator.GeneratePdf(stream, document);
             return stream.ToArray();
         }
         
         public static void GeneratePdf(this IDocument document, string filePath)
         {
-            using var stream = new FileStream(filePath, FileMode.Create);
-            document.GeneratePdf(stream);
+            var data = document.GeneratePdf();
+            
+            if (File.Exists(filePath))
+                File.Delete(filePath);
+            
+            File.WriteAllBytes(filePath, data);
         }
 
         public static void GeneratePdf(this IDocument document, Stream stream)
         {
-            DocumentGenerator.GeneratePdf(stream, document);
+            var data = document.GeneratePdf();
+            stream.Write(data, 0, data.Length);
         }
         
         #endregion

--- a/Source/FossPDF/Infrastructure/PageContext.cs
+++ b/Source/FossPDF/Infrastructure/PageContext.cs
@@ -44,5 +44,10 @@ namespace FossPDF.Infrastructure
         {
             return Locations.Find(x => x.Name == name);
         }
+
+        public int GetPageNumbers()
+        {
+            return Locations.Max(x => x.PageEnd);
+        }
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/QuestPDF/QuestPDF/issues/378

Now by calling `document.GeneratePdf`, it is possible to get the total number of pages that were generated.

`byte[] pdf = document.GeneratePdf(out int pageNumbers)`

Original pr: https://github.com/QuestPDF/QuestPDF/pull/871