### PR TITLE
 Add dynamic column width support

### DIFF
--- a/Source/FossPDF/Elements/Table/Table.cs
+++ b/Source/FossPDF/Elements/Table/Table.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using FossPDF.Drawing;
-using FossPDF.Fluent;
 using FossPDF.Infrastructure;
 
 namespace FossPDF.Elements.Table
@@ -15,6 +12,10 @@ namespace FossPDF.Elements.Table
         
         public List<TableColumnDefinition> Columns { get; set; } = new();
         public List<TableCell> Cells { get; set; } = new();
+        public List<TableCell> AllCells { get; set; } = new();
+        public Dictionary<int, float> ColumnsWidth { get; set; } = new();
+        public Action<Dictionary<int, float>> AfterUpdateColumnsWidth { get; set; }
+
         public bool ExtendLastCellsToTableBottom { get; set; }
         
         private bool CacheInitialized { get; set; }
@@ -149,6 +150,15 @@ namespace FossPDF.Elements.Table
         
         private void UpdateColumnsWidth(float availableWidth)
         {
+            if (ColumnsWidth.Any())
+            {
+                foreach (var column in Columns)
+                {
+                    column.Width = ColumnsWidth[Columns.IndexOf(column)];
+                }
+                return;
+            }
+
             var constantWidth = Columns.Sum(x => x.ConstantSize);
             var relativeWidth = Columns.Sum(x => x.RelativeSize);
 
@@ -158,6 +168,64 @@ namespace FossPDF.Elements.Table
             {
                 column.Width = column.ConstantSize + column.RelativeSize * widthPerRelativeUnit;
             }
+
+            var cells = AllCells.Where(c => c is { ColumnSpan: 1, RowSpan: 1 });
+
+            foreach (var column in Columns.Where(c => c.AllowShrink))
+            {
+                var index = Columns.IndexOf(column);
+                var cellsInColumn = cells.Where(c => c.Column == index + 1);
+                if (cellsInColumn.Any())
+                {
+                    ColumnsWidth.Add(index, cellsInColumn.Max(c => c.Measure(Size.Max).Width));
+                    column.Width = Math.Min(column.Width, ColumnsWidth[index]);
+                }
+            }
+
+            var remainingWidth = availableWidth - Columns.Sum(c => c.Width);
+            while (remainingWidth > 0)
+            {
+                var columnsThatGrow = Columns.Where(c => c.AllowGrow).ToList();
+                var growStep = remainingWidth / columnsThatGrow.Count;
+                var anyColumnHasGrown = false;
+                foreach (var column in columnsThatGrow)
+                {
+                    var index = Columns.IndexOf(column);
+                    var cellsInColumn = cells.Where(c => c.Column == index + 1);
+                    if (!ColumnsWidth.ContainsKey(index))
+                    {
+                        ColumnsWidth.Add(index, cellsInColumn.Max(c => c.Measure(Size.Max).Width));
+                    }
+                    var newWidth = Math.Min(column.Width + growStep, ColumnsWidth[index]);
+                    if (newWidth > column.Width)
+                    {
+                        anyColumnHasGrown = true;
+                    }
+                    column.Width = newWidth;
+                    remainingWidth = availableWidth - Columns.Sum(c => c.Width);
+                    if (remainingWidth <= 0)
+                    {
+                        break;
+                    }
+                }
+                if (!anyColumnHasGrown)
+                {
+                    break;
+                }
+            }
+
+            if (remainingWidth > 0)
+            {
+                Columns.Last().Width += remainingWidth;
+            }
+
+            foreach (var column in Columns)
+            {
+                // Add missing columns, that don't auto size.
+                ColumnsWidth[Columns.IndexOf(column)] = column.Width;
+            }
+
+            AfterUpdateColumnsWidth?.Invoke(ColumnsWidth);
         }
         
         private ICollection<TableCellRenderingCommand> PlanLayout(Size availableSpace)

--- a/Source/FossPDF/Elements/Table/TableColumnDefinition.cs
+++ b/Source/FossPDF/Elements/Table/TableColumnDefinition.cs
@@ -7,10 +7,15 @@ namespace FossPDF.Elements.Table
 
         internal float Width { get; set; }
 
-        public TableColumnDefinition(float constantSize, float relativeSize)
+        public bool AllowShrink { get; set; }
+        public bool AllowGrow { get; set; }
+
+        public TableColumnDefinition(float constantSize, float relativeSize, bool allowShrink, bool allowGrow)
         {
             ConstantSize = constantSize;
             RelativeSize = relativeSize;
+            AllowShrink = allowShrink;
+            AllowGrow = allowGrow;
         }
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/QuestPDF/QuestPDF/discussions/517 
Add support for dynamic column width.
This currently only works for cells that don't use row or column spanning.

Original pr: https://github.com/QuestPDF/QuestPDF/pull/867